### PR TITLE
ES6 syntax with babel support

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,0 +1,9 @@
+{
+  "presets": [
+    [ "env", {
+      "targets": {
+        "node": "current"
+      }
+    }]
+  ]
+}

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+
+.gitignore
+.idea/
+node_modules/

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # What it is
-> A NodeJS module for interacting with the SMM (Super Mario Maker) api, designed for Cemu.
+> A NodeJS module for interacting with the [SMMDb API](http://smmdb.ddns.net/api) (Super Mario Maker), designed for Cemu.
 
 ---
 

--- a/index.js
+++ b/index.js
@@ -1,121 +1,124 @@
+import Request from 'request'
+import queryString from 'querystring'
 
-try {
-    var fs = require('original-fs');
-} catch (error) {
-  	var fs = require('fs');
-}
+import fs from 'fs'
 
-var request     = require('request').defaults({ encoding: null }),
-	querystring = require('querystring');
+const request = Request.defaults({ encoding: null });
 
-module.exports = {
-	'config': {
-        'API_KEY': null,
-        'errors': {
-        	'no_api_key': 'No API key provided'
-        }
-    },
-	apiKey: function(key) {
-  		this.config.API_KEY = key;
-	},
-	downloadCourse: function(courseId, target, cb) {
-	    var req = request({
-	        method: 'GET',
-	        uri: 'http://smmdb.ddns.net/courses/'+courseId
-	    });
-
-	    var out = fs.createWriteStream(target+'/smm-course-'+courseId+'.rar');
-	    req.pipe(out);
-
-	    req.on('end', function() {
-	        return cb();
-	    });
-	},
-	uploadCourse: function(path, cb) {
-
-		//return console.log("UPLOADING DOES NOT WORK IN THIS VERSION OF SMM-API.");
-
-		if (!this.config.API_KEY) {
-			console.log(this.config.errors['no_api_key']);
-			return cb("{'error': '"+this.config.errors['no_api_key']+"'}");
-		}
-
-	    var _in = request({
-	        method: 'POST',
-	        headers: {
-	        	'request': 'uploadcourse',
-		      	'apikey': this.config.API_KEY		      	
-		    },
-	        uri: 'http://smmdb.ddns.net/api'
-	    });
-
-	    var level = fs.createReadStream(path);
-
-	    var req = level.pipe(_in);
-
-	    req.on('data', function(data) {
-            console.log(data.toString());
-        });
-
-	    req.on('end', function() {
-	        return cb();
-	    });  
-	},
-	search: function(params, cb) {
-		var query = querystring.stringify(params);
-		apiRequest('GET', 'http://smmdb.ddns.net/api/getcourses?'+query, function(response) {
-          	return cb(response.body);
-      	});
-	},
-	starcourse: function(courseId, cb) {
-		if (!this.config.API_KEY) {
-			console.log(this.config.errors['no_api_key']);
-			return cb("{'error': '"+this.config.errors['no_api_key']+"'}");
-		}
-		var query = querystring.stringify({apikey: this.config.API_KEY, dostar: 1, courseid: courseId});
-		apiRequest('GET', 'http://smmdb.ddns.net/api/starcourse?'+query, function(response){
-          	return cb(response.body);
-      	});
-	},
-	unstarcourse: function(courseId, cb) {
-		if (!this.config.API_KEY) {
-			console.log(this.config.errors['no_api_key']);
-			return cb("{'error': '"+this.config.errors['no_api_key']+"'}");
-		}
-		var query = querystring.stringify({apikey: this.config.API_KEY, dostar: 0, courseid: courseId});
-		apiRequest('GET', 'http://smmdb.ddns.net/api/starcourse?'+query, function(response){
-          	return cb(response.body);
-      	});
-	},
-	complete: function(courseId, cb) {
-		if (!this.config.API_KEY) {
-			console.log(this.config.errors['no_api_key']);
-			return cb("{'error': '"+this.config.errors['no_api_key']+"'}");
-		}
-		var query = querystring.stringify({apikey: this.config.API_KEY, docomplete: 1, courseid: courseId});
-		apiRequest('GET', 'http://smmdb.ddns.net/api/completecourse?'+query, function(response){
-          	return cb(response.body);
-      	});
-	},
-	uncomplete: function(courseId, cb) {
-		if (!this.config.API_KEY) {
-			console.log(this.config.errors['no_api_key']);
-			return cb("{'error': '"+this.config.errors['no_api_key']+"'}");
-		}
-		var query = querystring.stringify({apikey: this.config.API_KEY, docomplete: 0, courseid: courseId});
-		apiRequest('GET', 'http://smmdb.ddns.net/api/completecourse?'+query, function(response) {
-          	return cb(response.body);
-      	});
-	}
-}
+const config = {
+    API_KEY: null,
+    errors: {
+        noAPIKey: 'No API key provided'
+    }
+};
 
 function apiRequest(method, url, cb) {
     request({
-       url : url,
-       method : method
-    }, function(error, response, body) {
-       var res = response.headers;
-       res.body = body.toString();
-       cb(res);
-    }); 
+        url : url,
+        method : method
+    }, (error, response, body) => {
+        let res = response.headers;
+        res.body = body.toString();
+        cb(res);
+    });
+}
+
+function setApiKey (key) {
+    config.API_KEY = key;
+}
+
+export function downloadCourse (courseId, target, cb) {
+    let req = request({
+        method: 'GET',
+        uri: 'http://smmdb.ddns.net/courses/'+courseId
+    });
+
+    let out = fs.createWriteStream(target+'/smm-course-'+courseId+'.rar');
+    req.pipe(out);
+
+    req.on('end', function() {
+        return cb();
+    });
+}
+
+export function uploadCourse (path, cb) {
+
+    //return console.log("UPLOADING DOES NOT WORK IN THIS VERSION OF SMM-API.");
+
+    if (!this.config.API_KEY) {
+        console.log(this.config.errors.noAPIKey);
+        return cb(JSON.stringify({ error: config.errors.noAPIKey }));
+    }
+
+    let _in = request({
+        method: 'POST',
+        headers: {
+            'request': 'uploadcourse',
+            'apikey': this.config.API_KEY
+        },
+        uri: 'http://smmdb.ddns.net/api'
+    });
+
+    let level = fs.createReadStream(path);
+
+    let req = level.pipe(_in);
+
+    req.on('data', data => {
+        console.log(data.toString());
+    });
+
+    req.on('end', () => {
+        return cb();
+    });
+}
+
+export function search (params, cb) {
+    let query = queryString.stringify(params);
+    apiRequest('GET', 'http://smmdb.ddns.net/api/getcourses?'+query, response => {
+        return cb(JSON.parse(response.body));
+    });
+}
+
+export function starCourse (courseId, cb) {
+    if (!this.config.API_KEY) {
+        console.log(this.config.errors.noAPIKey);
+        return cb(JSON.stringify({ error: config.errors.noAPIKey }));
+    }
+    let query = queryString.stringify({apikey: this.config.API_KEY, dostar: 1, courseid: courseId});
+    apiRequest('GET', 'http://smmdb.ddns.net/api/starcourse?'+query, response => {
+        return cb(JSON.parse(response.body));
+    });
+}
+
+export function unstarCourse (courseId, cb) {
+    if (!this.config.API_KEY) {
+        console.log(this.config.errors.noAPIKey);
+        return cb(JSON.stringify({ error: config.errors.noAPIKey }));
+    }
+    let query = queryString.stringify({apikey: this.config.API_KEY, dostar: 0, courseid: courseId});
+    apiRequest('GET', 'http://smmdb.ddns.net/api/starcourse?'+query, response => {
+        return cb(JSON.parse(response.body));
+    });
+}
+
+export function completeCourse (courseId, cb) {
+    if (!this.config.API_KEY) {
+        console.log(this.config.errors.noAPIKey);
+        return cb(JSON.stringify({ error: config.errors.noAPIKey }));
+    }
+    let query = queryString.stringify({apikey: this.config.API_KEY, docomplete: 1, courseid: courseId});
+    apiRequest('GET', 'http://smmdb.ddns.net/api/completecourse?'+query, response => {
+        return cb(JSON.parse(response.body));
+    });
+}
+
+export function uncompleteCourse(courseId, cb) {
+    if (!this.config.API_KEY) {
+        console.log(this.config.errors.noAPIKey);
+        return cb(JSON.stringify({ error: config.errors.noAPIKey }));
+    }
+    let query = queryString.stringify({apikey: this.config.API_KEY, docomplete: 0, courseid: courseId});
+    apiRequest('GET', 'http://smmdb.ddns.net/api/completecourse?'+query, response => {
+        return cb(JSON.parse(response.body));
+    });
 }

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "keywords": [
     "cemu",
     "smm",
+    "smmdb",
     "super",
     "mario",
     "maker",
@@ -14,5 +15,13 @@
     "wrapper"
   ],
   "author": "RedDucks",
-  "license": "ISC"
+  "license": "ISC",
+  "dependencies": {
+    "querystring": "^0.2.0",
+    "request": "^2.81.0"
+  },
+  "devDependencies": {
+    "babel-core": "^6.24.1",
+    "babel-preset-env": "^1.4.0"
+  }
 }


### PR DESCRIPTION
- ES6 syntax:
  - make ES6 syntax standard (arrow functions, import/export, let/const)
  - add babel support for transpilation to older Node versions
- object keys are always strings
```js
const config = {
    'API_KEY': null
};
```
is the same as
```js
const config = {
    API_KEY: null
};
```
- return parsed response instead of JSON
  - `JSON.stringify({ error: config.errors.noAPIKey })` is a lot easier to write than `"{'error': '"+this.config.errors['no_api_key']+"'}"`
- use camelCase as it is standard in Node
  - `querystring` -> `queryString` etc
- add already existing dependencies to package.json
  - `request` and `querystring`
- added link to SMMDB