### PR TITLE
Code cleanup and modern changes

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,97 +1,96 @@
-
 const API_BASE = 'https://smmdb.ddns.net/api/';
 
-var fs = require('fs'),
-	request = require('request').defaults({ encoding: null }),
-	querystring = require('querystring');
+let fs = require('fs');
+let request = require('request').defaults({ encoding: null }),
+let querystring = require('querystring');
+
+const { promisify } = require("util");
+const promiseRequest = promisify(request);
+
+let API_key = null;
+
+function getBody(object, callback=null) {
+	if (callback) {
+		request(object, (error, response, body) => {
+			if (error) return callback(error);
+			if (!response || response.statusCode !== 200) return callback('Invalid response code');
+			return callback(null, body);
+		});
+	} else {
+		let { body, statusCode, responce } = promiseRequest(object);
+		if (!responce || statusCode !== 200) return 'Invalid response code';
+		return body;
+	}
+}
 
 module.exports = {
-	'config': {
-        'API_KEY': null,
-        'errors': {
-        	'no_api_key': 'No API key provided'
-        }
-    },
-	apiKey: function(key) {
-  		this.config.API_KEY = key;
+	apiKey: (userKey) => {
+		API_key = userKey;
 	},
-	getStats: function(cb) {
-		request(API_BASE + 'getstats', (error, response, body) => {
-			if (error) return cb(error);
-			if (!response || response.statusCode !== 200) return cb('Invalid response code');
-			body = JSON.parse(body);
-			return cb(null, body);
-		});
+	getStats: (callback=null) => {
+		return getbody({ url: API_BASE + 'getstats', json: true }, callback);
 	},
-	searchCourses: function(query, cb) {
-		query = querystring.stringify(query);
-		request(API_BASE + 'getcourses?' + query, (error, response, body) => {
-			if (error) return cb(error);
-			if (!response || response.statusCode !== 200) return cb('Invalid response code');
-			body = JSON.parse(body);
-			return cb(null, body);
-		})
+	searchCourses: (query, callback=null) => {
+		let query = querystring.stringify(query);
+		return getbody({ url: API_BASE + 'getcourses?' + query, json: true }, callback);
 	},
-	downloadCourse: function(courseId, target, cb) {
+	downloadCourse: (courseId, target, callback) => {
 		var req = request({
-	        method: 'GET',
-	        uri: API_BASE + 'downloadcourse?id=' + courseId + '&type=zip'
-	    });
-
-	    var out = fs.createWriteStream(target + '/smm-course-' + courseId + '.zip');
-		req.pipe(out);
-		
-		req.on('error', (error) => {
-			return cb(error);
+			method: 'GET',
+			uri: API_BASE + 'downloadcourse?id=' + courseId + '&type=zip'
 		});
 
-		out.on('error', (error) => {
-			return cb(error);
+		var out = fs.createWriteStream(target + '/smm-course-' + courseId + '.zip');
+		req.pipe(out);
+
+		req.on('error', (error) => {
+			return callback(error);
 		});
 
 		out.on('finish', () => {
-			return cb();
+			return callback();
 		});
 	},
-	uploadCourse: function(buffer, cb) {
-		if (!this.config.API_KEY || this.config.API_KEY.trim() == '') {
-			return cb(this.config.errors.no_api_key);
+	uploadCourse: (buffer, callback=null) => {
+		if (!API_key || API_KEY.trim() == '') {
+			if (callback)
+				return callback('No API key provided');
+			else
+				return 'No API key provided';
 		}
 
-		request({
+		let object = {
 			method: 'POST',
 			url: API_BASE + 'uploadcourse',
 			useElectronNet: false,
 			body: buffer,
 			headers: {
-				'Authorization': 'APIKEY ' + this.config.API_KEY,
+				'Authorization': 'APIKEY ' + API_KEY,
 				'Content-Type': 'application/octet-stream'
-			}
-		}, (error, response, body) => {
-			if (error) return cb(error);
-			if (!response || response.statusCode !== 200) {
-				return cb('Invalid response code');
-			}
-			body = JSON.parse(body.toString());
-			return cb(null, body);
-		});
+			},
+			json: true
+		};
+
+		return getbody(object, callback);
 	},
-	starUnstarCourse: function(courseId, cb) {
-		if (!this.config.API_KEY || this.config.API_KEY.trim() == '') {
-			return cb(this.config.errors.no_api_key);
+	starUnstarCourse: function(courseId, callback=null) {
+		if (!API_key || API_KEY.trim() == '') {
+			if (callback)
+				return callback('No API key provided');
+			else
+				return 'No API key provided';
 		}
-		request({
+
+		let object = {
 			method: 'POST',
 			url: API_BASE + 'starcourse?id=' + courseId,
 			useElectronNet: false,
 			headers: {
-			  	'Authorization': 'APIKEY ' + this.config.API_KEY
-			}
-		}, (error, response, body) => {
-			if (error) return cb(error);
-			if (!response || response.statusCode !== 200) return cb('Invalid response code');
-			body = JSON.parse(body);
-			return cb(null, body);
-		});
+			  	'Authorization': 'APIKEY ' + API_KEY
+			},
+			json: true
+		};
+
+		return getbody(object, callback);
 	}
 }


### PR DESCRIPTION
1. Why was the configuration exported? Change that
2. If there's only one useful item in the config, just make that the only variable: Why is the no-api-text one of the items in the config?
3. make a function called getBody, which doesn't repeat the body request every function (removes lines)
4. Don't parse the JSON locally. Why do that when request offers just that?
4. Callbacks are now optional: You can now use promises.